### PR TITLE
Extend the 'Launch' quest category.

### DIFF
--- a/src/main/java/com/ordwen/odailyquests/quests/types/item/LaunchQuest.java
+++ b/src/main/java/com/ordwen/odailyquests/quests/types/item/LaunchQuest.java
@@ -3,8 +3,10 @@ package com.ordwen.odailyquests.quests.types.item;
 import com.ordwen.odailyquests.quests.types.shared.BasicQuest;
 import com.ordwen.odailyquests.quests.types.shared.ItemQuest;
 import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
 import org.bukkit.event.Event;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 
 public class LaunchQuest extends ItemQuest {
@@ -21,13 +23,34 @@ public class LaunchQuest extends ItemQuest {
     @Override
     public boolean canProgress(Event provided) {
         if (provided instanceof ProjectileLaunchEvent event) {
-            switch (event.getEntity().getType()) {
-                case ENDER_PEARL -> { return super.isRequiredItem(new ItemStack(Material.ENDER_PEARL)); }
-                case EGG -> { return super.isRequiredItem(new ItemStack(Material.EGG)); }
-                case ARROW -> { return super.isRequiredItem(new ItemStack(Material.ARROW)); }
-                case SNOWBALL -> { return super.isRequiredItem(new ItemStack(Material.SNOWBALL)); }
+            EntityType entityType = event.getEntity().getType();
+            ItemStack requiredItem = null;
+
+            switch (entityType) {
+                case ENDER_PEARL -> requiredItem = new ItemStack(Material.ENDER_PEARL);
+                case EGG -> requiredItem = new ItemStack(Material.EGG);
+                case ARROW -> requiredItem = new ItemStack(Material.ARROW);
+                case SNOWBALL -> requiredItem = new ItemStack(Material.SNOWBALL);
+                case THROWN_EXP_BOTTLE -> requiredItem = new ItemStack(Material.EXPERIENCE_BOTTLE);
+                case FIREWORK -> requiredItem = new ItemStack(Material.FIREWORK_ROCKET);
+            }
+
+            if (requiredItem != null) {
+                return super.isRequiredItem(requiredItem);
             }
         }
+
+        if (provided instanceof PlayerInteractEvent interactEvent) {
+            ItemStack item = interactEvent.getItem();
+            if (item != null && item.getType() == Material.FIREWORK_ROCKET) {
+                if (interactEvent.getPlayer().isGliding()) {
+                    return super.isRequiredItem(item);
+                }
+            }
+        }
+
         return false;
     }
+
+
 }


### PR DESCRIPTION
Allow the use of EXPERIENCE_BOTTLE and FIREWORK_ROCKET in the 'Launch' quest category.