### PR TITLE
CustomBlockData impl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ dependencies {
     /* Folia */
     implementation 'space.arim.morepaperlib:morepaperlib:0.4.3'
 
+    /* lib for antiglitch */
+    compileOnly 'com.jeff-media:custom-block-data:2.2.3'
+
     /* Mojang auth API for heads */
     compileOnly 'com.mojang:authlib:1.5.25'
 

--- a/src/main/java/com/ordwen/odailyquests/ODailyQuests.java
+++ b/src/main/java/com/ordwen/odailyquests/ODailyQuests.java
@@ -1,5 +1,6 @@
 package com.ordwen.odailyquests;
 
+import com.jeff_media.customblockdata.CustomBlockData;
 import com.ordwen.odailyquests.api.ODailyQuestsAPI;
 import com.ordwen.odailyquests.api.quests.QuestTypeRegistry;
 import com.ordwen.odailyquests.events.restart.RestartHandler;
@@ -117,6 +118,9 @@ public final class ODailyQuests extends JavaPlugin {
 
         /* Load debugger */
         new Debugger(this).loadDebugMode();
+
+        /* Hook CustomBlockData */
+        CustomBlockData.registerListener(this); // maybe not needed
 
         /* Register quest types */
         final QuestTypeRegistry questTypeRegistry = API.getQuestTypeRegistry();

--- a/src/main/java/com/ordwen/odailyquests/ODailyQuests.java
+++ b/src/main/java/com/ordwen/odailyquests/ODailyQuests.java
@@ -120,7 +120,7 @@ public final class ODailyQuests extends JavaPlugin {
         new Debugger(this).loadDebugMode();
 
         /* Hook CustomBlockData */
-        CustomBlockData.registerListener(this); // maybe not needed
+        CustomBlockData.registerListener(this);
 
         /* Register quest types */
         final QuestTypeRegistry questTypeRegistry = API.getQuestTypeRegistry();

--- a/src/main/java/com/ordwen/odailyquests/configuration/essentials/Antiglitch.java
+++ b/src/main/java/com/ordwen/odailyquests/configuration/essentials/Antiglitch.java
@@ -5,12 +5,15 @@ import org.bukkit.NamespacedKey;
 
 public class Antiglitch {
 
+    private Antiglitch() {}
+
     private static boolean storePlacedBlocks = false;
     private static boolean storeBrokenBlocks = false;
     private static boolean storeDroppedItems = false;
 
-    public static NamespacedKey BROKEN_KEY = new NamespacedKey(ODailyQuests.INSTANCE, "broken");
-    public static NamespacedKey DROPPED_BY = new NamespacedKey(ODailyQuests.INSTANCE, "dropped");
+    public static final NamespacedKey BROKEN_KEY = new NamespacedKey(ODailyQuests.INSTANCE, "odq_broken");
+    public static final NamespacedKey PLACED_KEY = new NamespacedKey(ODailyQuests.INSTANCE, "odq_placed");
+    public static final NamespacedKey DROPPED_KEY = new NamespacedKey(ODailyQuests.INSTANCE, "odq_dropped");
 
     /**
      * Set the configuration values for the anti-glitch system

--- a/src/main/java/com/ordwen/odailyquests/events/listeners/integrations/itemsadder/CustomBlockBreakListener.java
+++ b/src/main/java/com/ordwen/odailyquests/events/listeners/integrations/itemsadder/CustomBlockBreakListener.java
@@ -1,5 +1,7 @@
 package com.ordwen.odailyquests.events.listeners.integrations.itemsadder;
 
+import com.jeff_media.customblockdata.CustomBlockData;
+import com.ordwen.odailyquests.ODailyQuests;
 import com.ordwen.odailyquests.configuration.essentials.Antiglitch;
 
 import com.ordwen.odailyquests.configuration.essentials.Debugger;
@@ -9,6 +11,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.persistence.PersistentDataContainer;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -29,7 +32,8 @@ public class CustomBlockBreakListener extends PlayerProgressor implements Listen
         AtomicBoolean valid = new AtomicBoolean(true);
 
         if (Antiglitch.isStorePlacedBlocks()) {
-            if (!block.getMetadata("odailyquests:placed").isEmpty()) {
+            final PersistentDataContainer pdc = new CustomBlockData(block, ODailyQuests.INSTANCE);
+            if (pdc.has(Antiglitch.PLACED_KEY)) {
                 valid.set(false);
             }
         }

--- a/src/main/java/com/ordwen/odailyquests/events/listeners/item/BlockBreakListener.java
+++ b/src/main/java/com/ordwen/odailyquests/events/listeners/item/BlockBreakListener.java
@@ -1,5 +1,7 @@
 package com.ordwen.odailyquests.events.listeners.item;
 
+import com.jeff_media.customblockdata.CustomBlockData;
+import com.ordwen.odailyquests.ODailyQuests;
 import com.ordwen.odailyquests.configuration.essentials.Antiglitch;
 import com.ordwen.odailyquests.configuration.essentials.Debugger;
 import com.ordwen.odailyquests.configuration.integrations.ItemsAdderEnabled;
@@ -13,6 +15,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.persistence.PersistentDataContainer;
 
 public class BlockBreakListener extends PlayerProgressor implements Listener {
 
@@ -36,32 +39,42 @@ public class BlockBreakListener extends PlayerProgressor implements Listener {
             }
         }
 
-        boolean valid = true;
-
-        if (Antiglitch.isStorePlacedBlocks()) {
-            Debugger.addDebug("BlockBreakListener: onBlockBreakEvent checking for placed blocks.");
-            if (block.getBlockData() instanceof Ageable ageable) {
-                if (ageable.getAge() != ageable.getMaximumAge()) {
-                    Debugger.addDebug("BlockBreakListener: onBlockBreakEvent cancelled due to ageable block.");
-                    valid = false;
-                }
-            } else {
-                if (!block.getMetadata("odailyquests:placed").isEmpty()) {
-                    if (KGeneratorsHook.isKGeneratorsLocation(block.getLocation())) {
-                        Debugger.addDebug("BlockBreakListener: onBlockBreakEvent processing KGenerators generator.");
-                    } else {
-                        Debugger.addDebug("BlockBreakListener: onBlockBreakEvent cancelled due to placed block.");
-                        valid = false;
-                    }
-                }
-            }
-            Debugger.addDebug("BlockBreakListener: onBlockBreakEvent placed block check complete.");
-        }
+        boolean valid = canProgress(block);
 
         if (valid) {
             Debugger.addDebug("BlockBreakListener: onBlockBreakEvent summoned by " + player.getName() + " for " + block.getType() + ".");
             setPlayerQuestProgression(event, player, 1, "BREAK");
         }
+    }
+
+    /**
+     * Check if the block have been placed by the player.
+     * If so, check if the block is a crop and if it is mature, or if the block come from a generator.
+     *
+     * @param block the block that is being broken
+     * @return true if th quest progression can continue, false otherwise
+     */
+    private static boolean canProgress(Block block) {
+        if (Antiglitch.isStorePlacedBlocks()) {
+            Debugger.addDebug("BlockBreakListener: onBlockBreakEvent checking for placed blocks.");
+            if (block.getBlockData() instanceof Ageable ageable && ageable.getAge() != ageable.getMaximumAge()) {
+                Debugger.addDebug("BlockBreakListener: onBlockBreakEvent cancelled due to ageable block.");
+                return false;
+            }
+
+            final PersistentDataContainer pdc = new CustomBlockData(block, ODailyQuests.INSTANCE);
+            if (pdc.has(Antiglitch.PLACED_KEY)) {
+                if (KGeneratorsHook.isKGeneratorsLocation(block.getLocation())) {
+                    Debugger.addDebug("BlockBreakListener: onBlockBreakEvent processing KGenerators generator.");
+                } else {
+                    Debugger.addDebug("BlockBreakListener: onBlockBreakEvent cancelled due to placed block.");
+                    return false;
+                }
+            }
+            Debugger.addDebug("BlockBreakListener: onBlockBreakEvent placed block check complete.");
+        }
+
+        return true;
     }
 }
 

--- a/src/main/java/com/ordwen/odailyquests/events/listeners/item/BlockDropItemListener.java
+++ b/src/main/java/com/ordwen/odailyquests/events/listeners/item/BlockDropItemListener.java
@@ -1,5 +1,7 @@
 package com.ordwen.odailyquests.events.listeners.item;
 
+import com.jeff_media.customblockdata.CustomBlockData;
+import com.ordwen.odailyquests.ODailyQuests;
 import com.ordwen.odailyquests.configuration.essentials.Antiglitch;
 
 import com.ordwen.odailyquests.configuration.essentials.Debugger;
@@ -15,7 +17,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockDropItemEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.metadata.MetadataValue;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
@@ -55,39 +56,53 @@ public class BlockDropItemListener extends PlayerProgressor implements Listener 
         }
 
         // check if the block have been placed by the player
-        if (dataMaterial.isBlock()) {
-            if (Antiglitch.isStorePlacedBlocks()) {
-                if (!event.getBlock().getMetadata("odailyquests:placed").isEmpty()) {
-                    // check if type has changed
-                    final MetadataValue previousType = event.getBlock().getMetadata("odailyquests:type").stream().findFirst().orElse(null);
-                    if (previousType != null) {
-                        if (previousType.asString().equals(dataMaterial.name())) {
-                            Debugger.addDebug("BlockDropItemListener: onBlockDropItemEvent cancelled due to placed block.");
-                            return;
-                        } else {
-                            Debugger.addDebug("BlockDropItemListener: onBlockDropItemEvent block type has changed (" + previousType.asString() + " -> " + dataMaterial.name() + ").");
-                        }
-                    }
-                }
-            }
-        }
+        if (isPlayerPlacedBlock(event, dataMaterial)) return;
 
         handleDrops(event, player, drops);
 
         // check if the dropped item is a block that can be posed
-        if (dataMaterial.isBlock()) {
-            if (Antiglitch.isStoreBrokenBlocks()) {
-                Debugger.addDebug("BlockDropItemListener: onBlockDropItemEvent storing broken block.");
-                for (Item item : event.getItems()) {
-                    final ItemStack drop = item.getItemStack();
-                    Debugger.addDebug("BlockDropItemListener: onBlockDropItemEvent storing broken block: " + drop.getType());
-                    final ItemMeta dropMeta = drop.getItemMeta();
-                    if (dropMeta == null) continue;
+        handleStoreBrokenBlocks(dataMaterial, event);
+    }
 
-                    final PersistentDataContainer pdc = dropMeta.getPersistentDataContainer();
-                    pdc.set(Antiglitch.BROKEN_KEY, PersistentDataType.STRING, event.getPlayer().getUniqueId().toString());
-                    drop.setItemMeta(dropMeta);
-                }
+    /**
+     * Check if the block has been placed by the player.
+     *
+     * @param event    the event that triggered the listener
+     * @param material the material of the block
+     * @return true if the block has been placed by the player
+     */
+    private static boolean isPlayerPlacedBlock(BlockDropItemEvent event, Material material) {
+        if (material.isBlock() && Antiglitch.isStorePlacedBlocks()) {
+            final PersistentDataContainer pdc = new CustomBlockData(event.getBlock(), ODailyQuests.INSTANCE);
+            // check if type has changed
+            final String previousType = pdc.getOrDefault(Antiglitch.PLACED_KEY, PersistentDataType.STRING, material.name());
+            if (previousType.equals(material.name())) {
+                Debugger.addDebug("BlockDropItemListener: onBlockDropItemEvent cancelled due to placed block.");
+                return true;
+            } else {
+                Debugger.addDebug("BlockDropItemListener: onBlockDropItemEvent block type has changed (" + previousType + " -> " + material.name() + ").");
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Store the broken blocks by the player by adding a unique identifier to the dropped item.
+     *
+     * @param event the event that triggered the listener
+     */
+    private static void handleStoreBrokenBlocks(Material material, BlockDropItemEvent event) {
+        if (material.isBlock() && Antiglitch.isStoreBrokenBlocks()) {
+            Debugger.addDebug("BlockDropItemListener: onBlockDropItemEvent storing broken block.");
+            for (Item item : event.getItems()) {
+                final ItemStack drop = item.getItemStack();
+                Debugger.addDebug("BlockDropItemListener: onBlockDropItemEvent storing broken block: " + drop.getType());
+                final ItemMeta dropMeta = drop.getItemMeta();
+                if (dropMeta == null) continue;
+
+                final PersistentDataContainer pdc = dropMeta.getPersistentDataContainer();
+                pdc.set(Antiglitch.BROKEN_KEY, PersistentDataType.STRING, event.getPlayer().getUniqueId().toString());
+                drop.setItemMeta(dropMeta);
             }
         }
     }

--- a/src/main/java/com/ordwen/odailyquests/events/listeners/item/BlockPlaceListener.java
+++ b/src/main/java/com/ordwen/odailyquests/events/listeners/item/BlockPlaceListener.java
@@ -1,5 +1,6 @@
 package com.ordwen.odailyquests.events.listeners.item;
 
+import com.jeff_media.customblockdata.CustomBlockData;
 import com.ordwen.odailyquests.ODailyQuests;
 import com.ordwen.odailyquests.configuration.essentials.Antiglitch;
 import com.ordwen.odailyquests.configuration.essentials.Debugger;
@@ -12,7 +13,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
@@ -51,8 +51,8 @@ public class BlockPlaceListener extends PlayerProgressor implements Listener {
 
         if (Antiglitch.isStorePlacedBlocks()) {
             Debugger.addDebug("BlockPlaceListener: onBlockPlaceEvent storing placed block.");
-            block.setMetadata("odailyquests:placed", new FixedMetadataValue(ODailyQuests.INSTANCE, player.getUniqueId().toString()));
-            block.setMetadata("odailyquests:type", new FixedMetadataValue(ODailyQuests.INSTANCE, block.getType().name()));
+            final PersistentDataContainer pdc = new CustomBlockData(block, ODailyQuests.INSTANCE);
+            pdc.set(Antiglitch.PLACED_KEY, PersistentDataType.STRING, block.getType().name());
         }
     }
 }

--- a/src/main/java/com/ordwen/odailyquests/events/listeners/item/PickupItemListener.java
+++ b/src/main/java/com/ordwen/odailyquests/events/listeners/item/PickupItemListener.java
@@ -25,7 +25,7 @@ public class PickupItemListener extends PlayerProgressor implements Listener {
             if (Antiglitch.isStoreDroppedItems()) {
                 if (item.hasItemMeta()) {
                     final PersistentDataContainer pdc = item.getItemMeta().getPersistentDataContainer();
-                    final String droppedKey = pdc.get(Antiglitch.DROPPED_BY, PersistentDataType.STRING);
+                    final String droppedKey = pdc.get(Antiglitch.DROPPED_KEY, PersistentDataType.STRING);
 
                     if (droppedKey != null) return;
                 }

--- a/src/main/java/com/ordwen/odailyquests/events/listeners/item/PlayerDropItemListener.java
+++ b/src/main/java/com/ordwen/odailyquests/events/listeners/item/PlayerDropItemListener.java
@@ -21,7 +21,7 @@ public class PlayerDropItemListener implements Listener {
 
             if (itemMeta != null) {
                 final PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
-                pdc.set(Antiglitch.DROPPED_BY, PersistentDataType.STRING, event.getPlayer().getUniqueId().toString());
+                pdc.set(Antiglitch.DROPPED_KEY, PersistentDataType.STRING, event.getPlayer().getUniqueId().toString());
                 item.setItemMeta(itemMeta);
             }
         }

--- a/src/main/java/com/ordwen/odailyquests/events/listeners/item/StructureGrowListener.java
+++ b/src/main/java/com/ordwen/odailyquests/events/listeners/item/StructureGrowListener.java
@@ -1,11 +1,14 @@
 package com.ordwen.odailyquests.events.listeners.item;
 
+import com.jeff_media.customblockdata.CustomBlockData;
 import com.ordwen.odailyquests.ODailyQuests;
 import com.ordwen.odailyquests.configuration.essentials.Antiglitch;
 import com.ordwen.odailyquests.configuration.essentials.Debugger;
+import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.world.StructureGrowEvent;
+import org.bukkit.persistence.PersistentDataContainer;
 
 public class StructureGrowListener implements Listener {
 
@@ -20,8 +23,9 @@ public class StructureGrowListener implements Listener {
         if (Antiglitch.isStorePlacedBlocks()) {
             Debugger.addDebug("StructureGrowListener: onStructureGrowEvent checking for placed blocks.");
             for (int i = 0; i < event.getBlocks().size(); i++) {
-                final var block = event.getBlocks().get(i);
-                if (!block.getMetadata("odailyquests:placed").isEmpty()) {
+                final Block block = event.getBlocks().get(i).getBlock();
+                final PersistentDataContainer pdc = new CustomBlockData(block, ODailyQuests.INSTANCE);
+                if (pdc.has(Antiglitch.PLACED_KEY)) {
                     Debugger.addDebug("StructureGrowListener: block at coordinates " + block.getX() + ", " + block.getY() + ", " + block.getZ() + " is a placed block. Removing metadataKey.");
                     block.removeMetadata("odailyquests:placed", ODailyQuests.INSTANCE);
                 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,7 +10,7 @@ softdepend: [ Vault, TokenManager, Citizens, PlaceholderAPI, PlayerPoints, Mythi
 libraries:
   - com.zaxxer:HikariCP:5.0.1
   - com.h2database:h2:2.1.214
-  - com.jeff_media:custom-block-data:2.2.3
+  - com.jeff-media:custom-block-data:2.2.3
 commands:
   dquests:
     description: default player command

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,6 +10,7 @@ softdepend: [ Vault, TokenManager, Citizens, PlaceholderAPI, PlayerPoints, Mythi
 libraries:
   - com.zaxxer:HikariCP:5.0.1
   - com.h2database:h2:2.1.214
+  - com.jeff_media:custom-block-data:2.2.3
 commands:
   dquests:
     description: default player command


### PR DESCRIPTION
Replacement of the current logic for saving posed blocks by the use of CustomBlockData, so that blocks are always taken into account by the antiglitch after the server is restarted or the block is moved.