### PR TITLE
Add configurable option for maximum rerolls per player

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.ordwen'
-version="3.0.1"
+version="3.0.2"
 
 def ciVersion = System.getenv("ORG_GRADLE_PROJECT_version")
 if (ciVersion != null && !ciVersion.trim().isEmpty()) {

--- a/src/main/java/com/ordwen/odailyquests/commands/admin/handlers/ARerollCommand.java
+++ b/src/main/java/com/ordwen/odailyquests/commands/admin/handlers/ARerollCommand.java
@@ -68,7 +68,7 @@ public class ARerollCommand extends AdminCommandBase {
             int count = playerQuests.getRecentlyRolled();
             if (playerQuests.rerollQuest(index - 1, target, true)) {
                 confirmationToSender(sender, index, playerName);
-                confirmationToTarget(index, RerollMaximum.getMaxRerolls()-(count+1), target);
+                confirmationToTarget(index, RerollMaximum.getMaxRerolls()-count, target);
             }
         }
     }

--- a/src/main/java/com/ordwen/odailyquests/commands/admin/handlers/ARerollCommand.java
+++ b/src/main/java/com/ordwen/odailyquests/commands/admin/handlers/ARerollCommand.java
@@ -2,6 +2,7 @@ package com.ordwen.odailyquests.commands.admin.handlers;
 
 import com.ordwen.odailyquests.api.commands.admin.AdminCommandBase;
 import com.ordwen.odailyquests.configuration.essentials.QuestsPerCategory;
+import com.ordwen.odailyquests.configuration.essentials.RerollMaximum;
 import com.ordwen.odailyquests.enums.QuestsMessages;
 import com.ordwen.odailyquests.enums.QuestsPermissions;
 import com.ordwen.odailyquests.quests.player.PlayerQuests;
@@ -65,9 +66,9 @@ public class ARerollCommand extends AdminCommandBase {
         if (activeQuests.containsKey(playerName)) {
             final PlayerQuests playerQuests = activeQuests.get(playerName);
             int count = playerQuests.getRecentlyRolled();
-            if (playerQuests.rerollQuest(index - 1, target)) {
+            if (playerQuests.rerollQuest(index - 1, target, true)) {
                 confirmationToSender(sender, index, playerName);
-                confirmationToTarget(index, count-1, target);
+                confirmationToTarget(index, RerollMaximum.getMaxRerolls()-(count+1), target);
             }
         }
     }

--- a/src/main/java/com/ordwen/odailyquests/commands/admin/handlers/ARerollCommand.java
+++ b/src/main/java/com/ordwen/odailyquests/commands/admin/handlers/ARerollCommand.java
@@ -64,9 +64,10 @@ public class ARerollCommand extends AdminCommandBase {
 
         if (activeQuests.containsKey(playerName)) {
             final PlayerQuests playerQuests = activeQuests.get(playerName);
+            int count = playerQuests.getRecentlyRolled();
             if (playerQuests.rerollQuest(index - 1, target)) {
                 confirmationToSender(sender, index, playerName);
-                confirmationToTarget(index, target);
+                confirmationToTarget(index, count-1, target);
             }
         }
     }
@@ -93,9 +94,9 @@ public class ARerollCommand extends AdminCommandBase {
      * @param index  the index of the quest that was rerolled
      * @param target the player who had their quest rerolled
      */
-    private void confirmationToTarget(int index, Player target) {
+    private void confirmationToTarget(int index, int remaining, Player target) {
         final String msg = QuestsMessages.QUEST_REROLLED.toString();
-        if (msg != null) target.sendMessage(msg.replace("%index%", String.valueOf(index)));
+        if (msg != null) target.sendMessage(msg.replace("%index%", String.valueOf(index)).replace("%remaining%", String.valueOf(remaining)));
     }
 
     @Override

--- a/src/main/java/com/ordwen/odailyquests/commands/player/handlers/PRerollCommand.java
+++ b/src/main/java/com/ordwen/odailyquests/commands/player/handlers/PRerollCommand.java
@@ -61,8 +61,9 @@ public class PRerollCommand extends PlayerCommandBase {
 
         if (activeQuests.containsKey(playerName)) {
             final PlayerQuests playerQuests = activeQuests.get(playerName);
+            int count = playerQuests.getRecentlyRolled();
             if (playerQuests.rerollQuest(index - 1, player)) {
-                rerollConfirm(index, player);
+                rerollConfirm(index, count-1, player);
             }
         }
     }
@@ -73,9 +74,9 @@ public class PRerollCommand extends PlayerCommandBase {
      * @param index  the index of the quest that was rerolled
      * @param target the player who had their quest rerolled
      */
-    private void rerollConfirm(int index, Player target) {
+    private void rerollConfirm(int index, int remaining, Player target) {
         final String msg = QuestsMessages.QUEST_REROLLED.toString();
-        if (msg != null) target.sendMessage(msg.replace("%index%", String.valueOf(index)));
+        if (msg != null) target.sendMessage(msg.replace("%index%", String.valueOf(index)).replace("%remaining%", String.valueOf(remaining)));
     }
 
     /**

--- a/src/main/java/com/ordwen/odailyquests/commands/player/handlers/PRerollCommand.java
+++ b/src/main/java/com/ordwen/odailyquests/commands/player/handlers/PRerollCommand.java
@@ -2,6 +2,7 @@ package com.ordwen.odailyquests.commands.player.handlers;
 
 import com.ordwen.odailyquests.api.commands.player.PlayerCommandBase;
 import com.ordwen.odailyquests.configuration.essentials.QuestsPerCategory;
+import com.ordwen.odailyquests.configuration.essentials.RerollMaximum;
 import com.ordwen.odailyquests.enums.QuestsMessages;
 import com.ordwen.odailyquests.enums.QuestsPermissions;
 import com.ordwen.odailyquests.quests.player.PlayerQuests;
@@ -62,8 +63,8 @@ public class PRerollCommand extends PlayerCommandBase {
         if (activeQuests.containsKey(playerName)) {
             final PlayerQuests playerQuests = activeQuests.get(playerName);
             int count = playerQuests.getRecentlyRolled();
-            if (playerQuests.rerollQuest(index - 1, player)) {
-                rerollConfirm(index, count-1, player);
+            if (playerQuests.rerollQuest(index - 1, player, false)) {
+                rerollConfirm(index, RerollMaximum.getMaxRerolls()-(count+1), player);
             }
         }
     }

--- a/src/main/java/com/ordwen/odailyquests/configuration/ConfigFactory.java
+++ b/src/main/java/com/ordwen/odailyquests/configuration/ConfigFactory.java
@@ -43,6 +43,7 @@ public class ConfigFactory {
         configs.put(SafetyMode.class, new SafetyMode(configurationFile));
         configs.put(QuestsPerCategory.class, new QuestsPerCategory(configurationFile));
         configs.put(RerollNotAchieved.class, new RerollNotAchieved(configurationFile));
+        configs.put(RerollMaximum.class, new RerollMaximum(configurationFile));
         configs.put(Synchronization.class, new Synchronization(configurationFile));
         configs.put(RenewInterval.class, new RenewInterval(configurationFile));
         configs.put(RenewTime.class, new RenewTime(configurationFile));

--- a/src/main/java/com/ordwen/odailyquests/configuration/essentials/RerollMaximum.java
+++ b/src/main/java/com/ordwen/odailyquests/configuration/essentials/RerollMaximum.java
@@ -1,0 +1,29 @@
+package com.ordwen.odailyquests.configuration.essentials;
+
+import com.ordwen.odailyquests.configuration.ConfigFactory;
+import com.ordwen.odailyquests.configuration.IConfigurable;
+import com.ordwen.odailyquests.files.implementations.ConfigurationFile;
+
+public class RerollMaximum implements IConfigurable {
+
+    private final ConfigurationFile configurationFile;
+    private int rerollMaximum;
+
+    public RerollMaximum(ConfigurationFile configurationFile) {
+        this.configurationFile = configurationFile;
+    }
+
+    @Override
+    public void load() {
+        final String path = "reroll_maximum";
+        rerollMaximum = configurationFile.getConfig().getInt(path);
+    }
+
+    private static RerollMaximum getInstance() {
+        return ConfigFactory.getConfig(RerollMaximum.class);
+    }
+
+    public static int getMaxRerolls() {
+        return getInstance().rerollMaximum;
+    }
+}

--- a/src/main/java/com/ordwen/odailyquests/enums/QuestsMessages.java
+++ b/src/main/java/com/ordwen/odailyquests/enums/QuestsMessages.java
@@ -49,7 +49,7 @@ public enum QuestsMessages {
     ALL_QUESTS_ACHIEVED_CONNECT("all_quests_achieved_connect", "&aYou have completed all your daily quests !"),
     QUESTS_RENEWED("quests_renewed", "&aYou have new daily quests to complete !"),
     QUESTS_RENEWED_ADMIN("quests_renewed_admin", "&eYou have reset the quests of %target%."),
-    QUEST_REROLLED("quest_rerolled", "&aYou have rerolled your quest number %index% !"),
+    QUEST_REROLLED("quest_rerolled", "&aYou have rerolled your quest number %index% -- %remaining% rerolls left!"),
     QUEST_REROLLED_ADMIN("quest_rerolled_admin", "&eYou have rerolled the quest number %index% of %target%."),
     NO_AVAILABLE_QUESTS_IN_CATEGORY("no_available_quests_in_category", "&cThere are no available quests in this category to assign."),
     QUEST_SET_ADMIN("quest_set_admin", "&eYou have set quest %quest_id% (%quest%&r&e) in slot %slot% for %target% in %category%."),
@@ -91,6 +91,7 @@ public enum QuestsMessages {
 
     CANNOT_COMPLETE_QUEST_WITH_OFF_HAND("cannot_complete_quest_with_off_hand", "&cAll required items must be in your inventory, not in your off hand."),
     CANNOT_REROLL_IF_ACHIEVED("cannot_reroll_if_achieved", "&cYou can't reroll a quest that you have already achieved!"),
+    CANNOT_REROLL_IF_MAX("cannot_reroll_if_max", "&cYou can't reroll any more quests!"),
 
     PLUGIN_RELOADED("plugin_reloaded", "&aThe plugin has been reloaded successfully!"),
     ERROR_INVENTORY("error_inventory", "&cAn error occurred while opening the inventory."),

--- a/src/main/java/com/ordwen/odailyquests/enums/SQLQuery.java
+++ b/src/main/java/com/ordwen/odailyquests/enums/SQLQuery.java
@@ -10,6 +10,7 @@ public enum SQLQuery {
                     `player_timestamp` BIGINT NOT NULL,
                     `achieved_quests` TINYINT NOT NULL,
                     `total_achieved_quests` INT NOT NULL,
+                    `recent_rerolls` INT NOT NULL DEFAULT 0,
                     CONSTRAINT `odq_pk_player` PRIMARY KEY (`player_uuid`)
                 );
             """),
@@ -39,12 +40,13 @@ public enum SQLQuery {
             """),
 
     MYSQL_SAVE_PLAYER("""
-                INSERT INTO `odq_player` (`player_uuid`, `player_timestamp`, `achieved_quests`, `total_achieved_quests`)
-                VALUES (?, ?, ?, ?)
+                INSERT INTO `odq_player` (`player_uuid`, `player_timestamp`, `achieved_quests`, `total_achieved_quests`, `recent_rerolls`)
+                VALUES (?, ?, ?, ?, ?)
                 ON DUPLICATE KEY UPDATE
                     `player_timestamp` = VALUES(`player_timestamp`),
                     `achieved_quests` = VALUES(`achieved_quests`),
                     `total_achieved_quests` = VALUES(`total_achieved_quests`);
+                    `recent_rerolls` = VALUES(`recent_rerolls`);
             """),
 
     MYSQL_SAVE_PROGRESS("""
@@ -73,6 +75,7 @@ public enum SQLQuery {
                     `player_timestamp` INTEGER NOT NULL,
                     `achieved_quests` INTEGER NOT NULL,
                     `total_achieved_quests` INTEGER NOT NULL,
+                    `recent_rerolls` INTEGER NOT NULL DEFAULT 0,
                     PRIMARY KEY (`player_uuid`)
                 );
             """),
@@ -101,8 +104,8 @@ public enum SQLQuery {
             """),
 
     SQLITE_SAVE_PLAYER("""
-                INSERT OR REPLACE INTO `odq_player` (`player_uuid`, `player_timestamp`, `achieved_quests`, `total_achieved_quests`)
-                VALUES (?, ?, ?, ?);
+                INSERT OR REPLACE INTO `odq_player` (`player_uuid`, `player_timestamp`, `achieved_quests`, `total_achieved_quests`, `recent_rerolls`)
+                VALUES (?, ?, ?, ?, ?);
             """),
 
     SQLITE_SAVE_PROGRESS("""
@@ -118,7 +121,7 @@ public enum SQLQuery {
     // Common queries //
 
     LOAD_PLAYER("""
-                SELECT player_timestamp, achieved_quests, total_achieved_quests FROM `odq_player`
+                SELECT player_timestamp, achieved_quests, total_achieved_quests, recent_rerolls FROM `odq_player`
                 WHERE player_uuid = ?;
             """),
 

--- a/src/main/java/com/ordwen/odailyquests/quests/player/PlayerQuests.java
+++ b/src/main/java/com/ordwen/odailyquests/quests/player/PlayerQuests.java
@@ -161,11 +161,12 @@ public class PlayerQuests {
      *
      * @param index  zero-based slot of the quest to reroll (must be within bounds of the current ordered keys)
      * @param player the player for whom the reroll is performed (used for permission checks and messaging)
+     * @param bypassMax boolean is true if triggered by an admin, false otherwise (used for bypassing recent reroll logic)
      * @return {@code true} if the reroll succeeded; {@code false} otherwise (e.g., reroll not allowed,
      * no available quest, or category resolution error)
      * @throws IndexOutOfBoundsException if {@code index} is out of range for the current quest list
      */
-    public boolean rerollQuest(int index, Player player) {
+    public boolean rerollQuest(int index, Player player, boolean bypassMax) {
         // Snapshot ordered keys to address a specific slot consistently.
         final List<AbstractQuest> oldQuests = new ArrayList<>(this.quests.keySet());
         final AbstractQuest questToRemove = oldQuests.get(index);
@@ -177,7 +178,7 @@ public class PlayerQuests {
         }
 
         // Guard: configuration may set a maximum amount of rerolled quests.
-        if (!isRerollAllowedMaximum(player)) {
+        if (!bypassMax && !isRerollAllowedMaximum(player)) {
             return false;
         }
 
@@ -209,7 +210,7 @@ public class PlayerQuests {
         this.quests.putAll(newPlayerQuests);
 
         // Increment recently rerolled count
-        addRecentReroll(1);
+        if (!bypassMax) addRecentReroll(1);
 
         // If the removed quest was previously achieved, adjust counters accordingly.
         updateAchievementsAfterRerollIfNeeded(progressionToRemove, categoryName, questToRemove);

--- a/src/main/java/com/ordwen/odailyquests/quests/player/progression/QuestLoaderUtils.java
+++ b/src/main/java/com/ordwen/odailyquests/quests/player/progression/QuestLoaderUtils.java
@@ -90,6 +90,7 @@ public class QuestLoaderUtils {
 
         playerQuests.setTotalAchievedQuests(totalAchievedQuests);
         playerQuests.setTotalAchievedQuestsByCategory(totalAchievedQuestsByCategory);
+        playerQuests.setRecentRerolls(0);
 
         final String msg = QuestsMessages.QUESTS_RENEWED.getMessage(player);
         if (msg != null && player.hasPermission(QuestsPermissions.QUESTS_PROGRESS.get())) {

--- a/src/main/java/com/ordwen/odailyquests/quests/player/progression/storage/sql/LoadProgressionSQL.java
+++ b/src/main/java/com/ordwen/odailyquests/quests/player/progression/storage/sql/LoadProgressionSQL.java
@@ -63,6 +63,7 @@ public class LoadProgressionSQL extends ProgressionLoader {
             long timestamp = 0;
             int achievedQuests = 0;
             int totalAchievedQuests = 0;
+            int recentRerolls = 0;
 
             try (final Connection connection = sqlManager.getConnection();
                  final PreparedStatement preparedStatement = connection.prepareStatement(SQLQuery.LOAD_PLAYER.getQuery())) {
@@ -77,6 +78,7 @@ public class LoadProgressionSQL extends ProgressionLoader {
                         timestamp = resultSet.getLong("player_timestamp");
                         achievedQuests = resultSet.getInt("achieved_quests");
                         totalAchievedQuests = resultSet.getInt("total_achieved_quests");
+                        recentRerolls = resultSet.getInt("recent_rerolls");
 
                         Debugger.write(playerName + " has stored data.");
                     } else {
@@ -90,14 +92,14 @@ public class LoadProgressionSQL extends ProgressionLoader {
             }
 
             if (hasStoredData) {
-                loadStoredData(player, activeQuests, timestamp, totalAchievedQuests, quests, achievedQuests);
+                loadStoredData(player, activeQuests, timestamp, totalAchievedQuests, quests, achievedQuests, recentRerolls);
             } else {
                 QuestLoaderUtils.loadNewPlayerQuests(playerName, activeQuests, new HashMap<>(), 0);
             }
         }, Duration.ofMillis(PlayerDataLoadDelay.getDelay()));
     }
 
-    private void loadStoredData(Player player, Map<String, PlayerQuests> activeQuests, long timestamp, int totalAchievedQuests, LinkedHashMap<AbstractQuest, Progression> quests, int achievedQuests) {
+    private void loadStoredData(Player player, Map<String, PlayerQuests> activeQuests, long timestamp, int totalAchievedQuests, LinkedHashMap<AbstractQuest, Progression> quests, int achievedQuests, int recentRerolls) {
         final String playerName = player.getName();
 
         Debugger.write(playerName + " has data in the database.");
@@ -117,6 +119,7 @@ public class LoadProgressionSQL extends ProgressionLoader {
             playerQuests.setAchievedQuests(achievedQuests);
             playerQuests.setTotalAchievedQuests(totalAchievedQuests);
             playerQuests.setTotalAchievedQuestsByCategory(categoryStats);
+            playerQuests.setRecentRerolls(recentRerolls);
 
             activeQuests.put(playerName, playerQuests);
             if (Logs.isEnabled()) {

--- a/src/main/java/com/ordwen/odailyquests/quests/player/progression/storage/sql/SaveProgressionSQL.java
+++ b/src/main/java/com/ordwen/odailyquests/quests/player/progression/storage/sql/SaveProgressionSQL.java
@@ -49,18 +49,19 @@ public class SaveProgressionSQL {
         long timestamp = playerQuests.getTimestamp();
         int achievedQuests = playerQuests.getAchievedQuests();
         int totalAchievedQuests = playerQuests.getTotalAchievedQuests();
+        int recentRerolls = playerQuests.getRecentlyRolled();
 
         final Map<AbstractQuest, Progression> quests = playerQuests.getQuests();
         final Map<String, Integer> totalAchievedByCategory = playerQuests.getTotalAchievedQuestsByCategory();
 
         if (isServerStopping) {
             Debugger.write("Saving player " + playerName + " progression (server is stopping or migration is in progress).");
-            saveDatas(playerName, playerUuid, timestamp, achievedQuests, totalAchievedQuests, quests, totalAchievedByCategory);
+            saveDatas(playerName, playerUuid, timestamp, achievedQuests, totalAchievedQuests, quests, totalAchievedByCategory, recentRerolls);
         } else {
             ODailyQuests.morePaperLib.scheduling().asyncScheduler().run(() -> {
                 Debugger.write("Saving player " + playerName + " progression asynchronously");
 
-                saveDatas(playerName, playerUuid, timestamp, achievedQuests, totalAchievedQuests, quests, totalAchievedByCategory);
+                saveDatas(playerName, playerUuid, timestamp, achievedQuests, totalAchievedQuests, quests, totalAchievedByCategory, recentRerolls);
             });
         }
     }
@@ -74,8 +75,9 @@ public class SaveProgressionSQL {
      * @param achievedQuests      achieved quests.
      * @param totalAchievedQuests total achieved quests.
      * @param quests              quests.
+     * @param recentRerolls       recently rerolled count.
      */
-    private void saveDatas(String playerName, String playerUuid, long timestamp, int achievedQuests, int totalAchievedQuests, Map<AbstractQuest, Progression> quests, Map<String, Integer> totalAchievedByCategory) {
+    private void saveDatas(String playerName, String playerUuid, long timestamp, int achievedQuests, int totalAchievedQuests, Map<AbstractQuest, Progression> quests, Map<String, Integer> totalAchievedByCategory, int recentRerolls) {
         try (Connection conn = sqlManager.getConnection()) {
             if (conn == null) {
                 PluginLogger.error("Database connection unavailable");
@@ -91,6 +93,7 @@ public class SaveProgressionSQL {
                 playerStatement.setLong(2, timestamp);
                 playerStatement.setInt(3, achievedQuests);
                 playerStatement.setInt(4, totalAchievedQuests);
+                playerStatement.setInt(5, recentRerolls);
                 playerStatement.executeUpdate();
 
                 Debugger.write("Player " + playerName + " data saved");

--- a/src/main/java/com/ordwen/odailyquests/quests/player/progression/storage/yaml/LoadProgressionYAML.java
+++ b/src/main/java/com/ordwen/odailyquests/quests/player/progression/storage/yaml/LoadProgressionYAML.java
@@ -59,6 +59,7 @@ public class LoadProgressionYAML extends ProgressionLoader {
         final long timestamp = playerSection.getLong(".timestamp");
         final int achievedQuests = playerSection.getInt(".achievedQuests");
         final int totalAchievedQuests = playerSection.getInt(".totalAchievedQuests");
+        final int recentRerolls = playerSection.getInt(".recentRolls");
 
         final Map<String, Integer> totalAchievedQuestsByCategory = new HashMap<>();
         final ConfigurationSection statsSection = playerSection.getConfigurationSection("totalAchievedQuestsByCategory");
@@ -84,6 +85,7 @@ public class LoadProgressionYAML extends ProgressionLoader {
         playerQuests.setAchievedQuests(achievedQuests);
         playerQuests.setTotalAchievedQuests(totalAchievedQuests);
         playerQuests.setTotalAchievedQuestsByCategory(totalAchievedQuestsByCategory);
+        playerQuests.setRecentRerolls(recentRerolls);
 
         activeQuests.put(playerName, playerQuests);
         if (Logs.isEnabled()) {

--- a/src/main/java/com/ordwen/odailyquests/quests/player/progression/storage/yaml/SaveProgressionYAML.java
+++ b/src/main/java/com/ordwen/odailyquests/quests/player/progression/storage/yaml/SaveProgressionYAML.java
@@ -32,12 +32,14 @@ public class SaveProgressionYAML {
         long timestamp = playerQuests.getTimestamp();
         int achievedQuests = playerQuests.getAchievedQuests();
         int totalAchievedQuests = playerQuests.getTotalAchievedQuests();
+        int recentRerolls = playerQuests.getRecentlyRolled();
 
         final Map<AbstractQuest, Progression> quests = playerQuests.getQuests();
 
         config.set(playerUuid + ".timestamp", timestamp);
         config.set(playerUuid + ".achievedQuests", achievedQuests);
         config.set(playerUuid + ".totalAchievedQuests", totalAchievedQuests);
+        config.set(playerUuid + ".recentRerolls", recentRerolls);
 
         int index = 1;
         for (Map.Entry<AbstractQuest, Progression> entry : quests.entrySet()) {

--- a/src/main/java/com/ordwen/odailyquests/tools/updater/config/ConfigUpdateManager.java
+++ b/src/main/java/com/ordwen/odailyquests/tools/updater/config/ConfigUpdateManager.java
@@ -6,6 +6,8 @@ import com.ordwen.odailyquests.tools.UpdateChecker;
 import com.ordwen.odailyquests.tools.updater.config.updates.Update223to224;
 import com.ordwen.odailyquests.tools.updater.config.updates.Update225to230;
 import com.ordwen.odailyquests.tools.updater.config.updates.Update230to300;
+import com.ordwen.odailyquests.tools.updater.config.updates.Update301to302;
+
 import org.bukkit.configuration.file.FileConfiguration;
 
 import java.util.LinkedHashMap;
@@ -22,6 +24,7 @@ public class ConfigUpdateManager {
         updaters.put("2.2.3", new Update223to224(plugin));
         updaters.put("2.2.5", new Update225to230(plugin));
         updaters.put("3.0.0", new Update230to300(plugin));
+        updaters.put("3.0.2", new Update301to302(plugin));
     }
 
     public void runUpdates() {

--- a/src/main/java/com/ordwen/odailyquests/tools/updater/config/updates/Update301to302.java
+++ b/src/main/java/com/ordwen/odailyquests/tools/updater/config/updates/Update301to302.java
@@ -1,0 +1,18 @@
+package com.ordwen.odailyquests.tools.updater.config.updates;
+
+import com.ordwen.odailyquests.ODailyQuests;
+import com.ordwen.odailyquests.tools.updater.config.ConfigUpdater;
+
+public class Update301to302 extends ConfigUpdater {
+
+    public Update301to302(ODailyQuests plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public void apply(ODailyQuests plugin, String version) {
+        setDefaultConfigItem("reroll_maximum", -1, config, configFile, false);
+
+        updateVersion(version);
+    }
+}

--- a/src/main/java/com/ordwen/odailyquests/tools/updater/database/DatabaseUpdateManager.java
+++ b/src/main/java/com/ordwen/odailyquests/tools/updater/database/DatabaseUpdateManager.java
@@ -4,6 +4,8 @@ import com.ordwen.odailyquests.ODailyQuests;
 import com.ordwen.odailyquests.tools.PluginLogger;
 import com.ordwen.odailyquests.tools.updater.database.updates.Update0to1;
 import com.ordwen.odailyquests.tools.updater.database.updates.Update1to2;
+import com.ordwen.odailyquests.tools.updater.database.updates.Update2to3;
+
 import org.bukkit.configuration.file.FileConfiguration;
 
 import java.util.LinkedHashMap;
@@ -19,6 +21,7 @@ public class DatabaseUpdateManager {
 
         updaters.put("1", new Update0to1(plugin));
         updaters.put("2", new Update1to2(plugin));
+        updaters.put("3", new Update2to3(plugin));
     }
 
     public void runUpdates() {

--- a/src/main/java/com/ordwen/odailyquests/tools/updater/database/updates/Update2to3.java
+++ b/src/main/java/com/ordwen/odailyquests/tools/updater/database/updates/Update2to3.java
@@ -1,0 +1,106 @@
+package com.ordwen.odailyquests.tools.updater.database.updates;
+
+import com.ordwen.odailyquests.ODailyQuests;
+import com.ordwen.odailyquests.configuration.essentials.Database;
+import com.ordwen.odailyquests.configuration.essentials.Debugger;
+import com.ordwen.odailyquests.enums.StorageMode;
+import com.ordwen.odailyquests.files.implementations.ProgressionFile;
+import com.ordwen.odailyquests.tools.PluginLogger;
+import com.ordwen.odailyquests.tools.updater.database.DatabaseUpdater;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.bukkit.configuration.file.FileConfiguration;
+
+public class Update2to3 extends DatabaseUpdater {
+
+    private static final String MYSQL_ADD_RECENT_REROLLS_COLUMN = """
+            ALTER TABLE `odq_player`
+            ADD COLUMN `recent_rerolls` INT NOT NULL DEFAULT 0;
+            """;
+
+    private static final String SQLITE_ADD_RECENT_REROLLS_COLUMN = """
+            ALTER TABLE `odq_player`
+            ADD COLUMN `recent_rerolls` INTEGER NOT NULL DEFAULT 0;
+            """;
+
+    public Update2to3(ODailyQuests plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public void apply(ODailyQuests plugin, String version) {
+        final StorageMode mode = Database.getMode();
+
+        if (mode == StorageMode.MYSQL) {
+            applyMySQL();
+        } else if (mode == StorageMode.SQLITE) {
+            applySQLite();
+        } else if (mode == StorageMode.YAML) {
+            applyYAML();
+        } else {
+            PluginLogger.info("No database update required for storage mode: " + mode);
+        }
+
+        updateVersion(version);
+    }
+
+    @Override
+    public void applyMySQL() {
+        Debugger.write("Applying MySQL database update 2 -> 3: adding recent_rerolls");
+        runSqlAlter(MYSQL_ADD_RECENT_REROLLS_COLUMN);
+    }
+
+    @Override
+    public void applySQLite() {
+        Debugger.write("Applying SQLite database update 2 -> 3: adding recent_rerolls");
+        runSqlAlter(SQLITE_ADD_RECENT_REROLLS_COLUMN);
+    }
+
+    @Override
+    public void applyYAML() {
+        Debugger.write("Applying YAML database update 2 -> 3: adding recentRerolls");
+
+        final ProgressionFile progression = this.progressionFile;
+        final FileConfiguration progressionConfig = progression.getConfig();
+
+        for (String playerKey : progressionConfig.getKeys(false)) {
+            final String path = playerKey + ".recentRerolls";
+
+            if (!progressionConfig.isSet(path)) {
+                progressionConfig.set(path, 0);
+                Debugger.write("Set recentRerolls = 0 for player entry " + playerKey);
+            }
+        }
+
+        try {
+            progressionConfig.save(progression.getFile());
+            PluginLogger.warn("YAML database update 2 -> 3 completed!");
+        } catch (IOException e) {
+            PluginLogger.error("An error occurred while saving YAML data during database update 2 -> 3:");
+            PluginLogger.error(e.getMessage());
+        }
+    }
+
+    private void runSqlAlter(String sql) {
+        try (Connection connection = databaseManager.getSqlManager().getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+
+            statement.executeUpdate();
+            PluginLogger.warn("SQL database update 2 -> 3 completed!");
+        } catch (SQLException e) {
+            final String msg = e.getMessage() != null ? e.getMessage().toLowerCase() : "";
+            if (msg.contains("duplicate column") || msg.contains("already exists")) {
+                Debugger.write("recent_rerolls column already exists in odq_player -- skipping!");
+            } else {
+                PluginLogger.error("Error while applying SQL database update 2 -> 3!");
+                PluginLogger.error(e.getMessage());
+                Debugger.write("Error while applying SQL database update 2 -> 3!");
+                Debugger.write(e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -306,6 +306,9 @@ complete_only_on_click: false
 # Determines if the quest can be rerolled even if it has already been completed, when using the reroll command.
 reroll_only_if_not_achieved: false
 
+# Determines max amount of times a player can reroll their quest in a day
+reroll_maximum: -1
+
 # If you are using MythicMobs, you can set this parameter to "true" to share the mobs between players.
 #
 # It means that if someone kill a mob, the quest progression will be updated for all players


### PR DESCRIPTION
+ updated plugin version 3.0.1->3.0.2
+ updated db version 2->3

**Servers can use this new max value to limit the total number of times a player can reroll a quest in a day.**