### PR TITLE
Add category groups with independent renewal schedules

### DIFF
--- a/src/main/java/com/ordwen/odailyquests/ODailyQuests.java
+++ b/src/main/java/com/ordwen/odailyquests/ODailyQuests.java
@@ -68,7 +68,7 @@ public final class ODailyQuests extends JavaPlugin {
      */
     private InterfacesManager interfacesManager;
     private FilesManager filesManager;
-    public TimerTask timerTask;
+    public TimerManager timerManager;
     private ReloadService reloadService;
     private CategoriesLoader categoriesLoader;
     private DatabaseManager databaseManager;
@@ -175,11 +175,12 @@ public final class ODailyQuests extends JavaPlugin {
 
         /* Init delayed task to draw new quests */
         if (TimestampMode.getTimestampMode() == 1) {
-            if (timerTask != null) {
-                timerTask.stop();
+            if (timerManager != null) {
+                timerManager.stop();
             }
 
-            timerTask = new TimerTask(LocalDateTime.now());
+            timerManager = new TimerManager();
+            timerManager.start(LocalDateTime.now());
         }
 
         PluginLogger.info("Plugin is started!");
@@ -283,9 +284,9 @@ public final class ODailyQuests extends JavaPlugin {
     @Override
     public void onDisable() {
         if (restartHandler != null) restartHandler.setServerStopping();
-        if (timerTask != null) {
-            timerTask.stop();
-            timerTask = null;
+        if (timerManager != null) {
+            timerManager.stop();
+            timerManager = null;
         }
 
         /* Avoid errors on reload */

--- a/src/main/java/com/ordwen/odailyquests/configuration/ConfigFactory.java
+++ b/src/main/java/com/ordwen/odailyquests/configuration/ConfigFactory.java
@@ -48,6 +48,7 @@ public class ConfigFactory {
         configs.put(Synchronization.class, new Synchronization(configurationFile));
         configs.put(RenewInterval.class, new RenewInterval(configurationFile));
         configs.put(RenewTime.class, new RenewTime(configurationFile));
+        configs.put(CategoryGroupsLoader.class, new CategoryGroupsLoader(configurationFile));
         configs.put(CheckForUpdate.class, new CheckForUpdate(configurationFile));
 
         // functionalities
@@ -87,9 +88,9 @@ public class ConfigFactory {
         // load all configs
         configs.values().forEach(IConfigurable::load);
 
-        // reload the timer task
-        if (ODailyQuests.INSTANCE.timerTask != null) {
-            ODailyQuests.INSTANCE.timerTask.reload();
+        // reload the timer manager
+        if (ODailyQuests.INSTANCE.timerManager != null) {
+            ODailyQuests.INSTANCE.timerManager.reload();
         }
     }
 

--- a/src/main/java/com/ordwen/odailyquests/configuration/essentials/CategoryGroupsLoader.java
+++ b/src/main/java/com/ordwen/odailyquests/configuration/essentials/CategoryGroupsLoader.java
@@ -1,0 +1,299 @@
+package com.ordwen.odailyquests.configuration.essentials;
+
+import com.ordwen.odailyquests.configuration.ConfigFactory;
+import com.ordwen.odailyquests.configuration.IConfigurable;
+import com.ordwen.odailyquests.files.implementations.ConfigurationFile;
+import com.ordwen.odailyquests.quests.categories.CategoryGroup;
+import com.ordwen.odailyquests.tools.PluginLogger;
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.time.Duration;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Loads and manages category groups from the configuration.
+ * <p>
+ * Category groups allow different categories to have different renewal schedules.
+ * If no groups are defined, a default legacy group is created containing all categories.
+ */
+public class CategoryGroupsLoader implements IConfigurable {
+
+    private static final List<DateTimeFormatter> TIME_FORMATTERS = List.of(
+            DateTimeFormatter.ofPattern("h:mma"),
+            DateTimeFormatter.ofPattern("ha"),
+            DateTimeFormatter.ofPattern("H:mm"),
+            DateTimeFormatter.ofPattern("H")
+    );
+
+    private static final String DEFAULT_TIME = "00:00";
+    private static final String DEFAULT_ZONE = "SystemDefault";
+    private static final String DEFAULT_INTERVAL = "1d";
+    private static final String LEGACY_GROUP_NAME = "default";
+
+    private final ConfigurationFile configurationFile;
+    private final Map<String, CategoryGroup> groups = new LinkedHashMap<>();
+    private final Map<String, String> categoryToGroup = new HashMap<>();
+    private boolean legacyMode = false;
+
+    public CategoryGroupsLoader(ConfigurationFile configurationFile) {
+        this.configurationFile = configurationFile;
+    }
+
+    @Override
+    public void load() {
+        groups.clear();
+        categoryToGroup.clear();
+
+        final ConfigurationSection groupsSection = configurationFile.getConfig().getConfigurationSection("category_groups");
+
+        if (groupsSection == null || groupsSection.getKeys(false).isEmpty()) {
+            legacyMode = true;
+            PluginLogger.info("No category_groups defined. Using legacy mode with global temporal settings.");
+            createLegacyGroup();
+            return;
+        }
+
+        legacyMode = false;
+        loadGroups(groupsSection);
+    }
+
+    /**
+     * Creates a legacy group containing all categories defined in quests_per_category,
+     * using the global renew_time and renew_interval settings.
+     */
+    private void createLegacyGroup() {
+        final ConfigurationSection questsSection = configurationFile.getConfig().getConfigurationSection("quests_per_category");
+        if (questsSection == null) {
+            PluginLogger.error("No quests_per_category section found. Cannot create legacy group.");
+            return;
+        }
+
+        final List<String> allCategories = new ArrayList<>(questsSection.getKeys(false));
+        final LocalTime renewTime = RenewTime.getRenewTime();
+        final Duration renewInterval = RenewInterval.getRenewInterval();
+        final ZoneId zoneId = RenewTime.getZoneId();
+
+        final CategoryGroup legacyGroup = new CategoryGroup(
+                LEGACY_GROUP_NAME,
+                allCategories,
+                renewTime,
+                renewInterval,
+                zoneId
+        );
+
+        groups.put(LEGACY_GROUP_NAME, legacyGroup);
+        for (String category : allCategories) {
+            categoryToGroup.put(category.toLowerCase(), LEGACY_GROUP_NAME);
+        }
+
+        PluginLogger.info("Created legacy group '" + LEGACY_GROUP_NAME + "' with " + allCategories.size() + " categories.");
+    }
+
+    /**
+     * Loads category groups from the configuration section.
+     */
+    private void loadGroups(ConfigurationSection groupsSection) {
+        final Set<String> assignedCategories = new HashSet<>();
+
+        for (String groupName : groupsSection.getKeys(false)) {
+            final ConfigurationSection groupSection = groupsSection.getConfigurationSection(groupName);
+            if (groupSection == null) {
+                PluginLogger.warn("Invalid group configuration for '" + groupName + "'. Skipping.");
+                continue;
+            }
+
+            final CategoryGroup group = parseGroup(groupName, groupSection, assignedCategories);
+            if (group != null) {
+                groups.put(groupName, group);
+                for (String category : group.getCategoryNames()) {
+                    categoryToGroup.put(category.toLowerCase(), groupName);
+                }
+                PluginLogger.info("Loaded category group '" + groupName + "' with categories: " + group.getCategoryNames()
+                        + " (interval: " + formatDuration(group.getRenewInterval()) + ")");
+            }
+        }
+
+        if (groups.isEmpty()) {
+            PluginLogger.warn("No valid category groups loaded. Falling back to legacy mode.");
+            legacyMode = true;
+            createLegacyGroup();
+        }
+    }
+
+    /**
+     * Parses a single category group from its configuration section.
+     */
+    private CategoryGroup parseGroup(String groupName, ConfigurationSection section, Set<String> assignedCategories) {
+        // Parse categories
+        final List<String> categories = section.getStringList("categories");
+        if (categories.isEmpty()) {
+            PluginLogger.error("Group '" + groupName + "' has no categories defined. Skipping.");
+            return null;
+        }
+
+        // Check for duplicate category assignments
+        for (String category : categories) {
+            final String lowerCategory = category.toLowerCase();
+            if (assignedCategories.contains(lowerCategory)) {
+                PluginLogger.error("Category '" + category + "' is already assigned to another group. Each category can only belong to one group.");
+                return null;
+            }
+            assignedCategories.add(lowerCategory);
+        }
+
+        // Parse temporal settings with fallback to global settings
+        final String timeStr = section.getString("renew_time", DEFAULT_TIME);
+        final String intervalStr = section.getString("renew_interval", DEFAULT_INTERVAL);
+        final String zoneStr = section.getString("renew_time_zone", DEFAULT_ZONE);
+
+        final LocalTime renewTime = parseTime(timeStr, groupName);
+        final Duration renewInterval = parseDuration(intervalStr, groupName);
+        final ZoneId zoneId = parseZone(zoneStr, groupName);
+
+        return new CategoryGroup(groupName, categories, renewTime, renewInterval, zoneId);
+    }
+
+    /**
+     * Parses a time string with multiple format support.
+     */
+    private LocalTime parseTime(String timeStr, String groupName) {
+        final String normalized = timeStr.toUpperCase().trim();
+        for (DateTimeFormatter formatter : TIME_FORMATTERS) {
+            try {
+                return LocalTime.parse(normalized, formatter);
+            } catch (DateTimeParseException ignored) {
+            }
+        }
+        PluginLogger.warn("Invalid time format '" + timeStr + "' for group '" + groupName + "'. Using default: " + DEFAULT_TIME);
+        return LocalTime.MIDNIGHT;
+    }
+
+    /**
+     * Parses a duration string (e.g., "1d", "7d", "12h", "1d12h").
+     */
+    private Duration parseDuration(String intervalStr, String groupName) {
+        final Pattern pattern = Pattern.compile("(\\d+)([dhm])");
+        final Matcher matcher = pattern.matcher(intervalStr.toLowerCase());
+        Duration duration = Duration.ZERO;
+
+        while (matcher.find()) {
+            int value = Integer.parseInt(matcher.group(1));
+            String unit = matcher.group(2);
+
+            duration = switch (unit) {
+                case "d" -> duration.plus(value, ChronoUnit.DAYS);
+                case "h" -> duration.plus(value, ChronoUnit.HOURS);
+                case "m" -> duration.plus(value, ChronoUnit.MINUTES);
+                default -> duration;
+            };
+        }
+
+        if (duration.isZero()) {
+            PluginLogger.warn("Invalid interval '" + intervalStr + "' for group '" + groupName + "'. Using default: " + DEFAULT_INTERVAL);
+            return Duration.ofDays(1);
+        }
+
+        return duration;
+    }
+
+    /**
+     * Parses a timezone string.
+     */
+    private ZoneId parseZone(String zoneStr, String groupName) {
+        if (zoneStr.equalsIgnoreCase(DEFAULT_ZONE)) {
+            return ZoneId.systemDefault();
+        }
+        try {
+            return ZoneId.of(zoneStr);
+        } catch (Exception e) {
+            PluginLogger.warn("Invalid timezone '" + zoneStr + "' for group '" + groupName + "'. Using system default.");
+            return ZoneId.systemDefault();
+        }
+    }
+
+    /**
+     * Formats a duration for logging purposes.
+     */
+    private String formatDuration(Duration duration) {
+        long days = duration.toDays();
+        long hours = duration.toHoursPart();
+        long minutes = duration.toMinutesPart();
+
+        StringBuilder sb = new StringBuilder();
+        if (days > 0) sb.append(days).append("d");
+        if (hours > 0) sb.append(hours).append("h");
+        if (minutes > 0) sb.append(minutes).append("m");
+        return sb.length() > 0 ? sb.toString() : "0m";
+    }
+
+    // Static accessor methods
+
+    private static CategoryGroupsLoader getInstance() {
+        return ConfigFactory.getConfig(CategoryGroupsLoader.class);
+    }
+
+    /**
+     * Checks if the plugin is running in legacy mode (no category groups defined).
+     *
+     * @return true if in legacy mode
+     */
+    public static boolean isLegacyMode() {
+        return getInstance().legacyMode;
+    }
+
+    /**
+     * Gets all loaded category groups.
+     *
+     * @return an unmodifiable map of group name to CategoryGroup
+     */
+    public static Map<String, CategoryGroup> getAllGroups() {
+        return Collections.unmodifiableMap(getInstance().groups);
+    }
+
+    /**
+     * Gets a category group by name.
+     *
+     * @param groupName the name of the group
+     * @return the CategoryGroup, or null if not found
+     */
+    public static CategoryGroup getGroup(String groupName) {
+        return getInstance().groups.get(groupName);
+    }
+
+    /**
+     * Gets the group that a category belongs to.
+     *
+     * @param categoryName the name of the category
+     * @return the CategoryGroup, or null if the category is not assigned to any group
+     */
+    public static CategoryGroup getGroupForCategory(String categoryName) {
+        final String groupName = getInstance().categoryToGroup.get(categoryName.toLowerCase());
+        return groupName != null ? getInstance().groups.get(groupName) : null;
+    }
+
+    /**
+     * Gets the name of the group that a category belongs to.
+     *
+     * @param categoryName the name of the category
+     * @return the group name, or null if not found
+     */
+    public static String getGroupNameForCategory(String categoryName) {
+        return getInstance().categoryToGroup.get(categoryName.toLowerCase());
+    }
+
+    /**
+     * Gets all group names.
+     *
+     * @return a set of all group names
+     */
+    public static Set<String> getGroupNames() {
+        return getInstance().groups.keySet();
+    }
+}

--- a/src/main/java/com/ordwen/odailyquests/events/listeners/integrations/itemsadder/CustomBlockBreakListener.java
+++ b/src/main/java/com/ordwen/odailyquests/events/listeners/integrations/itemsadder/CustomBlockBreakListener.java
@@ -13,6 +13,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -34,7 +35,7 @@ public class CustomBlockBreakListener extends PlayerProgressor implements Listen
 
         if (Antiglitch.isStorePlacedBlocks()) {
             final PersistentDataContainer pdc = new CustomBlockData(block, ODailyQuests.INSTANCE);
-            if (pdc.has(Antiglitch.PLACED_KEY)) {
+            if (pdc.has(Antiglitch.PLACED_KEY, PersistentDataType.STRING)) {
                 valid.set(false);
             }
         }

--- a/src/main/java/com/ordwen/odailyquests/events/listeners/item/BlockBreakListener.java
+++ b/src/main/java/com/ordwen/odailyquests/events/listeners/item/BlockBreakListener.java
@@ -18,6 +18,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
 
 public class BlockBreakListener extends PlayerProgressor implements Listener {
 
@@ -78,7 +79,7 @@ public class BlockBreakListener extends PlayerProgressor implements Listener {
             }
 
             final PersistentDataContainer pdc = new CustomBlockData(block, ODailyQuests.INSTANCE);
-            if (pdc.has(Antiglitch.PLACED_KEY)) {
+            if (pdc.has(Antiglitch.PLACED_KEY, PersistentDataType.STRING)) {
                 if (KGeneratorsHook.isKGeneratorsLocation(block.getLocation())) {
                     Debugger.write("BlockBreakListener: onBlockBreakEvent processing KGenerators generator.");
                 } else {
@@ -137,7 +138,7 @@ public class BlockBreakListener extends PlayerProgressor implements Listener {
         }
 
         final PersistentDataContainer pdc = new CustomBlockData(block, ODailyQuests.INSTANCE);
-        if (pdc.has(Antiglitch.PLACED_KEY)) {
+        if (pdc.has(Antiglitch.PLACED_KEY, PersistentDataType.STRING)) {
             Debugger.write("BlockBreakListener: isBlockCountable cancelled due to placed block.");
             return false;
         }

--- a/src/main/java/com/ordwen/odailyquests/events/listeners/item/StructureGrowListener.java
+++ b/src/main/java/com/ordwen/odailyquests/events/listeners/item/StructureGrowListener.java
@@ -10,6 +10,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.world.StructureGrowEvent;
 import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
 
 public class StructureGrowListener implements Listener {
 
@@ -26,7 +27,7 @@ public class StructureGrowListener implements Listener {
             for (int i = 0; i < event.getBlocks().size(); i++) {
                 final Block block = event.getBlocks().get(i).getBlock();
                 final PersistentDataContainer pdc = new CustomBlockData(block, ODailyQuests.INSTANCE);
-                if (pdc.has(Antiglitch.PLACED_KEY)) {
+                if (pdc.has(Antiglitch.PLACED_KEY, PersistentDataType.STRING)) {
                     Debugger.write("StructureGrowListener: block at coordinates " + block.getX() + ", " + block.getY() + ", " + block.getZ() + " is a placed block. Removing metadataKey.");
                     block.removeMetadata("odailyquests:placed", ODailyQuests.INSTANCE);
                 }

--- a/src/main/java/com/ordwen/odailyquests/quests/categories/CategoriesLoader.java
+++ b/src/main/java/com/ordwen/odailyquests/quests/categories/CategoriesLoader.java
@@ -1,6 +1,7 @@
 package com.ordwen.odailyquests.quests.categories;
 
 import com.ordwen.odailyquests.ODailyQuests;
+import com.ordwen.odailyquests.configuration.essentials.CategoryGroupsLoader;
 import com.ordwen.odailyquests.configuration.essentials.QuestAmountSetting;
 import com.ordwen.odailyquests.configuration.essentials.QuestsPerCategory;
 import com.ordwen.odailyquests.configuration.essentials.SafetyMode;
@@ -34,6 +35,7 @@ public class CategoriesLoader {
             final Integer requiredAmount = setting.getStaticAmount();
 
             final Category category = new Category(categoryName);
+            category.setGroupName(CategoryGroupsLoader.getGroupNameForCategory(categoryName));
             categories.put(categoryName, category);
 
             final FileConfiguration configFile = QuestsFiles.getQuestsConfigurationByCategory(categoryName);

--- a/src/main/java/com/ordwen/odailyquests/quests/categories/Category.java
+++ b/src/main/java/com/ordwen/odailyquests/quests/categories/Category.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 public class Category extends ArrayList<AbstractQuest> {
 
     private final String name;
+    private String groupName;
 
     public Category(String name) {
         this.name = name;
@@ -17,5 +18,21 @@ public class Category extends ArrayList<AbstractQuest> {
      */
     public String getName() {
         return this.name;
+    }
+
+    /**
+     * Get the name of the group this category belongs to.
+     * @return group name, or null if not assigned to a group (legacy mode)
+     */
+    public String getGroupName() {
+        return this.groupName;
+    }
+
+    /**
+     * Set the name of the group this category belongs to.
+     * @param groupName the group name
+     */
+    public void setGroupName(String groupName) {
+        this.groupName = groupName;
     }
 }

--- a/src/main/java/com/ordwen/odailyquests/quests/categories/CategoryGroup.java
+++ b/src/main/java/com/ordwen/odailyquests/quests/categories/CategoryGroup.java
@@ -1,0 +1,109 @@
+package com.ordwen.odailyquests.quests.categories;
+
+import com.ordwen.odailyquests.tools.RenewSchedule;
+
+import java.time.Duration;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.List;
+
+/**
+ * Represents a group of quest categories that share the same renewal schedule.
+ * <p>
+ * Each group has its own temporal settings (renew time, interval, timezone),
+ * allowing different categories to renew at different times (e.g., daily vs weekly).
+ */
+public class CategoryGroup {
+
+    private final String name;
+    private final List<String> categoryNames;
+    private final LocalTime renewTime;
+    private final Duration renewInterval;
+    private final ZoneId zoneId;
+
+    /**
+     * Constructs a new CategoryGroup.
+     *
+     * @param name          the unique name of the group (e.g., "daily", "weekly")
+     * @param categoryNames the names of categories belonging to this group
+     * @param renewTime     the time of day when quests renew
+     * @param renewInterval the interval between renewals
+     * @param zoneId        the timezone for renewal calculations
+     */
+    public CategoryGroup(String name, List<String> categoryNames, LocalTime renewTime, Duration renewInterval, ZoneId zoneId) {
+        this.name = name;
+        this.categoryNames = List.copyOf(categoryNames);
+        this.renewTime = renewTime;
+        this.renewInterval = renewInterval;
+        this.zoneId = zoneId;
+    }
+
+    /**
+     * Gets the name of this group.
+     *
+     * @return the group name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Gets the list of category names in this group.
+     *
+     * @return an immutable list of category names
+     */
+    public List<String> getCategoryNames() {
+        return categoryNames;
+    }
+
+    /**
+     * Gets the renewal time for this group.
+     *
+     * @return the local time of renewal
+     */
+    public LocalTime getRenewTime() {
+        return renewTime;
+    }
+
+    /**
+     * Gets the renewal interval for this group.
+     *
+     * @return the duration between renewals
+     */
+    public Duration getRenewInterval() {
+        return renewInterval;
+    }
+
+    /**
+     * Gets the timezone for this group.
+     *
+     * @return the zone ID
+     */
+    public ZoneId getZoneId() {
+        return zoneId;
+    }
+
+    /**
+     * Checks if a category belongs to this group.
+     *
+     * @param categoryName the name of the category to check
+     * @return true if the category is part of this group
+     */
+    public boolean containsCategory(String categoryName) {
+        return categoryNames.stream()
+                .anyMatch(name -> name.equalsIgnoreCase(categoryName));
+    }
+
+    /**
+     * Creates a {@link RenewSchedule.Settings} instance for this group.
+     * <p>
+     * This allows using the existing RenewSchedule utility methods
+     * with group-specific temporal settings.
+     *
+     * @param timestampMode the timestamp mode to use
+     * @return the schedule settings for this group
+     */
+    public RenewSchedule.Settings toScheduleSettings(int timestampMode) {
+        return new RenewSchedule.Settings(renewTime, renewInterval, zoneId, timestampMode);
+    }
+}

--- a/src/main/java/com/ordwen/odailyquests/tools/GroupTimerTask.java
+++ b/src/main/java/com/ordwen/odailyquests/tools/GroupTimerTask.java
@@ -1,0 +1,144 @@
+package com.ordwen.odailyquests.tools;
+
+import com.ordwen.odailyquests.api.ODailyQuestsAPI;
+import com.ordwen.odailyquests.configuration.essentials.TimestampMode;
+import com.ordwen.odailyquests.enums.QuestsMessages;
+import com.ordwen.odailyquests.quests.categories.CategoryGroup;
+import com.ordwen.odailyquests.quests.player.PlayerQuests;
+import com.ordwen.odailyquests.quests.player.QuestsManager;
+import com.ordwen.odailyquests.quests.player.progression.QuestLoaderUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.time.*;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Timer task for a specific category group.
+ * <p>
+ * Each group has its own timer that handles renewal at the configured interval.
+ * When the timer fires, only the quests belonging to this group's categories are renewed.
+ */
+public class GroupTimerTask {
+
+    private final CategoryGroup group;
+    private final ScheduledExecutorService scheduler;
+    private ScheduledFuture<?> scheduledTask;
+
+    /**
+     * Creates a new GroupTimerTask for the specified group.
+     *
+     * @param group     the category group this timer manages
+     * @param scheduler the shared scheduler to use
+     */
+    public GroupTimerTask(CategoryGroup group, ScheduledExecutorService scheduler) {
+        this.group = group;
+        this.scheduler = scheduler;
+    }
+
+    /**
+     * Schedules the next execution based on the group's temporal settings.
+     *
+     * @param start the starting date/time for calculation
+     */
+    public void scheduleNextExecution(LocalDateTime start) {
+        final RenewSchedule.Settings settings = group.toScheduleSettings(TimestampMode.getTimestampMode());
+
+        if (!RenewSchedule.isValid(settings)) {
+            PluginLogger.error("Invalid renew schedule for group '" + group.getName() + "'. Timer not scheduled.");
+            return;
+        }
+
+        final ZonedDateTime now = start.atZone(ZoneId.systemDefault()).withZoneSameInstant(settings.zone());
+        final ZonedDateTime next = RenewSchedule.nextExecutionAtOrAfter(now, settings);
+
+        long initialDelayNanos = Duration.between(
+                ZonedDateTime.now(ZoneId.systemDefault()),
+                next.withZoneSameInstant(ZoneId.systemDefault())
+        ).toNanos();
+
+        scheduledTask = scheduler.schedule(this::executeAndReschedule, initialDelayNanos, TimeUnit.NANOSECONDS);
+
+        PluginLogger.info("Group '" + group.getName() + "' scheduled for renewal at " + next + ".");
+    }
+
+    /**
+     * Executes the renewal for this group and reschedules the next execution.
+     */
+    private void executeAndReschedule() {
+        PluginLogger.info("Renewing quests for group '" + group.getName() + "'.");
+
+        for (Player player : Bukkit.getServer().getOnlinePlayers()) {
+            renewPlayerQuestsForGroup(player);
+        }
+
+        scheduleNextExecution(LocalDateTime.now());
+    }
+
+    /**
+     * Renews a player's quests for this group only.
+     *
+     * @param player the player whose quests to renew
+     */
+    private void renewPlayerQuestsForGroup(Player player) {
+        // Send renewal message to player
+        final String msg = QuestsMessages.NEW_DAY.toString();
+        if (msg != null) {
+            final String formattedMsg = msg.replace("%group%", group.getName());
+            player.sendMessage(formattedMsg);
+        }
+
+        final PlayerQuests playerQuests = ODailyQuestsAPI.getPlayerQuests(player.getName());
+        if (playerQuests == null) {
+            PluginLogger.warn("Could not find quests for player " + player.getName() + " during group renewal.");
+            return;
+        }
+
+        // Get current totals to preserve
+        final int totalAchievedQuests = playerQuests.getTotalAchievedQuests();
+        final Map<String, Integer> totalAchievedQuestsByCategory = playerQuests.getTotalAchievedQuestsByCategory();
+
+        // Renew only quests for this group
+        QuestLoaderUtils.loadNewPlayerQuestsForGroup(
+                player.getName(),
+                QuestsManager.getActiveQuests(),
+                totalAchievedQuestsByCategory,
+                totalAchievedQuests,
+                group
+        );
+    }
+
+    /**
+     * Cancels this timer.
+     */
+    public void cancel() {
+        if (scheduledTask != null) {
+            scheduledTask.cancel(false);
+        }
+    }
+
+    /**
+     * Gets the category group this timer manages.
+     *
+     * @return the category group
+     */
+    public CategoryGroup getGroup() {
+        return group;
+    }
+
+    /**
+     * Gets the next scheduled execution time.
+     *
+     * @return the next execution time, or null if not scheduled
+     */
+    public ZonedDateTime getNextExecution() {
+        final RenewSchedule.Settings settings = group.toScheduleSettings(TimestampMode.getTimestampMode());
+        if (!RenewSchedule.isValid(settings)) {
+            return null;
+        }
+        return RenewSchedule.nextExecutionAtOrAfter(ZonedDateTime.now(settings.zone()), settings);
+    }
+}

--- a/src/main/java/com/ordwen/odailyquests/tools/TimeRemain.java
+++ b/src/main/java/com/ordwen/odailyquests/tools/TimeRemain.java
@@ -1,8 +1,10 @@
 package com.ordwen.odailyquests.tools;
 
 import com.ordwen.odailyquests.api.ODailyQuestsAPI;
+import com.ordwen.odailyquests.configuration.essentials.CategoryGroupsLoader;
 import com.ordwen.odailyquests.configuration.essentials.RenewInterval;
 import com.ordwen.odailyquests.configuration.essentials.TimestampMode;
+import com.ordwen.odailyquests.quests.categories.CategoryGroup;
 
 import java.time.*;
 
@@ -33,6 +35,41 @@ public class TimeRemain {
             restMillis = RenewSchedule.millisUntilNext(now, s);
         } else {
             final long timestamp = ODailyQuestsAPI.getPlayerQuests(playerName).getTimestamp();
+            restMillis = (timestamp + renewInterval.toMillis()) - System.currentTimeMillis();
+            restMillis = Math.max(0L, restMillis);
+        }
+
+        return formatTimeRemain(restMillis);
+    }
+
+    /**
+     * Get the time remaining before the next quests draw for a specific category group.
+     *
+     * @param playerName player to consider.
+     * @param groupName  the name of the category group.
+     * @return the time remaining as a formatted String, or null if group not found.
+     */
+    public static String timeRemainForGroup(String playerName, String groupName) {
+        final CategoryGroup group = CategoryGroupsLoader.getGroup(groupName);
+        if (group == null) {
+            return null;
+        }
+
+        long restMillis;
+
+        final Duration renewInterval = group.getRenewInterval();
+        if (renewInterval == null || renewInterval.isZero() || renewInterval.isNegative()) {
+            return formatTimeRemain(0);
+        }
+
+        if (TimestampMode.getTimestampMode() == 1) {
+            final RenewSchedule.Settings s = group.toScheduleSettings(TimestampMode.getTimestampMode());
+            if (!RenewSchedule.isValid(s)) return formatTimeRemain(0);
+
+            final ZonedDateTime now = ZonedDateTime.now(s.zone());
+            restMillis = RenewSchedule.millisUntilNext(now, s);
+        } else {
+            final long timestamp = ODailyQuestsAPI.getPlayerQuests(playerName).getTimestamp(groupName);
             restMillis = (timestamp + renewInterval.toMillis()) - System.currentTimeMillis();
             restMillis = Math.max(0L, restMillis);
         }

--- a/src/main/java/com/ordwen/odailyquests/tools/TimerManager.java
+++ b/src/main/java/com/ordwen/odailyquests/tools/TimerManager.java
@@ -1,0 +1,102 @@
+package com.ordwen.odailyquests.tools;
+
+import com.ordwen.odailyquests.configuration.essentials.CategoryGroupsLoader;
+import com.ordwen.odailyquests.quests.categories.CategoryGroup;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Manages multiple GroupTimerTask instances, one for each category group.
+ * <p>
+ * This class provides a centralized way to start, stop, and reload all timers
+ * associated with different category groups, each with their own renewal schedule.
+ */
+public class TimerManager {
+
+    private final Map<String, GroupTimerTask> timers = new HashMap<>();
+    private final ScheduledExecutorService scheduler;
+
+    /**
+     * Creates a new TimerManager with a shared thread pool.
+     */
+    public TimerManager() {
+        // Use a shared thread pool for all timers to avoid creating too many threads
+        this.scheduler = Executors.newScheduledThreadPool(
+                Math.max(1, CategoryGroupsLoader.getGroupNames().size())
+        );
+    }
+
+    /**
+     * Starts all timers for configured category groups.
+     *
+     * @param start the starting date/time for scheduling
+     */
+    public void start(LocalDateTime start) {
+        PluginLogger.info("Starting timer manager with " + CategoryGroupsLoader.getGroupNames().size() + " group(s).");
+
+        for (Map.Entry<String, CategoryGroup> entry : CategoryGroupsLoader.getAllGroups().entrySet()) {
+            final String groupName = entry.getKey();
+            final CategoryGroup group = entry.getValue();
+
+            final GroupTimerTask timer = new GroupTimerTask(group, scheduler);
+            timer.scheduleNextExecution(start);
+            timers.put(groupName, timer);
+
+            PluginLogger.info("Started timer for group '" + groupName + "'.");
+        }
+    }
+
+    /**
+     * Reloads all timers with the current configuration.
+     * Cancels existing timers and creates new ones.
+     */
+    public void reload() {
+        PluginLogger.info("Reloading timer manager...");
+
+        // Cancel all existing timers
+        for (GroupTimerTask timer : timers.values()) {
+            timer.cancel();
+        }
+        timers.clear();
+
+        // Start new timers based on current configuration
+        start(LocalDateTime.now());
+    }
+
+    /**
+     * Stops all timers and shuts down the scheduler.
+     */
+    public void stop() {
+        PluginLogger.info("Stopping timer manager...");
+
+        for (GroupTimerTask timer : timers.values()) {
+            timer.cancel();
+        }
+        timers.clear();
+
+        scheduler.shutdownNow();
+    }
+
+    /**
+     * Gets the timer for a specific group.
+     *
+     * @param groupName the name of the group
+     * @return the GroupTimerTask, or null if not found
+     */
+    public GroupTimerTask getTimerForGroup(String groupName) {
+        return timers.get(groupName);
+    }
+
+    /**
+     * Gets all active timers.
+     *
+     * @return a map of group name to timer
+     */
+    public Map<String, GroupTimerTask> getAllTimers() {
+        return new HashMap<>(timers);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -97,6 +97,50 @@ renew_time_zone: "SystemDefault"
 # Remember to surround the value with double quotes, otherwise it will not work!
 renew_interval: "1d"
 
+# ============================================================================
+# CATEGORY GROUPS - Optional advanced feature
+# ============================================================================
+# Define groups of categories with different renewal schedules.
+# Each group can have its own renew_time, renew_interval, and time zone.
+#
+# When this section is defined, the global renew_time and renew_interval above
+# are ignored in favor of per-group settings.
+#
+# If this section is commented out or empty, all categories will use the
+# global settings above (default behavior).
+#
+# IMPORTANT: Each category must belong to exactly one group. Categories not
+# listed in any group will cause an error at startup.
+#
+# Example configuration with daily and weekly quest groups:
+# category_groups:
+#   daily:
+#     categories:
+#       - easy
+#       - medium
+#     renew_time: "00:00"
+#     renew_interval: "1d"
+#     renew_time_zone: "SystemDefault"  # optional, defaults to SystemDefault
+#   weekly:
+#     categories:
+#       - hard
+#     renew_time: "00:00"
+#     renew_interval: "7d"
+#
+# Uncomment and modify below to enable category groups:
+# category_groups:
+#   daily:
+#     categories:
+#       - easy
+#       - medium
+#     renew_time: "00:00"
+#     renew_interval: "1d"
+#   weekly:
+#     categories:
+#       - hard
+#     renew_time: "00:00"
+#     renew_interval: "7d"
+
 # Delay in seconds before the status message is displayed when a player joins the server.
 # Corresponds to quests_in_progress and all_quests_achieved_connect messages.
 join_message_delay: 1.0


### PR DESCRIPTION
Hi, I added a group system for a friend who uses this plugin to define several categories with different time frames. He has configured it but has not yet used it in production. If you like the idea, feel free to grab the code :)

Thanks!

AI generated:

> Summary


  - Introduce Category Groups, allowing server administrators to assign quest categories to groups with independent
  renewal timers (e.g., easy/medium quests renew daily while hard quests renew weekly)
  - Add new PlaceholderAPI placeholders for per-group time remaining (%odailyquests_drawin_<group>%) and per-group
  achieved count (%odailyquests_achieved_group_<group>%)
  - Fix PersistentDataContainer.has() calls to use explicit PersistentDataType.STRING for broader Bukkit API
  compatibility

>   Changes


  New files

  - CategoryGroupsLoader — Reads category_groups from config.yml; falls back to legacy mode (single global timer) when
  not defined
  - CategoryGroup — Data model representing a group of categories sharing a renewal schedule
  - GroupTimerTask — Per-group scheduled task that renews only the quests belonging to its group
  - TimerManager — Replaces the old TimerTask, manages multiple GroupTimerTask instances
  - QuestLoaderUtils — Utility for group-specific quest renewal while preserving other groups' quests
  - TimeRemain — Calculates remaining time until next renewal for a specific group

  Modified files

  - PlayerQuests — Refactored to store timestamps and reroll counts per group instead of globally (backward-compatible)
  - ProgressionLoader — Extended to handle per-group timestamps and rerolls with legacy migration support
  - QuestsManager — Added selectRandomQuestsForGroup() for group-specific quest selection
  - PAPIExpansion — Registered new group-aware placeholders
  - config.yml — Added documented example configuration for category groups

>   Bugfix

  - BlockBreakListener, CustomBlockBreakListener, StructureGrowListener — Added explicit PersistentDataType.STRING
  parameter to PersistentDataContainer.has() calls

  Backward Compatibility

  Full backward compatibility is maintained. When no category_groups section is defined in config.yml, the plugin
  operates in legacy mode with a single global renewal timer, identical to previous behavior. Deprecated methods in
  PlayerQuests continue to work by operating across all groups.